### PR TITLE
update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,12 @@ RUN addgroup -g 1000 rubygems && \
     apk add linux-headers build-base curl openldap-dev git && \
     rm -rf /var/cache/apk/*
 
+RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.8/main' >> /etc/apk/repositories && \
+    echo 'http://dl-cdn.alpinelinux.org/alpine/v3.8/community' >> /etc/apk/repositories
+
+RUN apk update && \
+    apk add --no-cache libssl1.0
+
 ADD . /application
 RUN chown -R rubygems:rubygems /application
 


### PR DESCRIPTION
- fix libssl error:
```ruby-gems            | /application/vendor/bundle/ruby/2.6.0/gems/puma-4.3.0/lib/puma/server.rb:15:in `require': Error loading shared library libssl.so.1.0.0: No such file or directory (needed by /application/vendor/bundle/ruby/2.6.0/gems/puma-4.3.0/lib/puma/puma_http11.so) - /application/vendor/bundle/ruby/2.6.0/gems/puma-4.3.0/lib/puma/puma_http11.so (LoadError)```
- fix gem folder permissions when uploading a new gem in `/application/data` folder by creating the `data` folder beforehand